### PR TITLE
ローカルのActionCableアダプタをasyncに変更する

### DIFF
--- a/config/cable.yml
+++ b/config/cable.yml
@@ -1,6 +1,7 @@
 development:
-  adapter: redis
-  url: redis://localhost:6379/1
+  adapter: async
+#  adapter: redis
+#  url: redis://localhost:6379/1
 
 test:
   adapter: test


### PR DESCRIPTION
Redisだとローカル環境セットアップのハードルが上がって開発に参加しにくくなりそうなので、asyncに変更しました。
動作確認済みです。

![xY20i4z1P5](https://user-images.githubusercontent.com/1148320/209650967-a92c6955-cb56-4e17-b042-a5e48fc212f2.gif)
