### PR TITLE
rails db:migrate etcがwarningでおちるのを回避する (pg1.5.1以降)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,8 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'bootstrap_form'
 
+gem 'warning'
+
 group :development, :test do
   gem 'debug', platforms: %i[mri mingw x64_mingw]
   gem 'sqlite3'

--- a/config/initializers/warning_silences.rb
+++ b/config/initializers/warning_silences.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+# Silence warnings:
+
+# PG::Coder.new(hash) is deprecated. Please use keyword arguments instead!
+Warning.ignore(/PG::Coder.new\(hash\) is deprecated/)


### PR DESCRIPTION
pg1.5.1以降を利用していると、rails db:migrate etcが下記のwarningでおちるので、
このプルリクエストで下記のwarningを無視するようにします。

```
PG::Coder.new(hash) is deprecated. Please use keyword arguments instead!
```